### PR TITLE
Issue 868 rotate mariadb log

### DIFF
--- a/src/roles/database/tasks/configure.yml
+++ b/src/roles/database/tasks/configure.yml
@@ -64,6 +64,29 @@
     mode: 0640
   when: mysql_log == "" and mysql_log_error != ""
 
+- name: Rotate MariaDB log
+  blockinfile:
+    path: /etc/logrotate.d/mariadb
+    create: yes
+    block: |
+/var/log/mariadb/mariadb.log {
+        create 640 mysql mysql
+        notifempty
+       daily
+        rotate 3
+        missingok
+        compress
+    postrotate
+       # just if mysqld is really running
+       if test -x /usr/bin/mysqladmin && \
+          /usr/bin/mysqladmin ping &>/dev/null
+       then
+          /usr/bin/mysqladmin flush-logs
+       fi
+    endscript
+}
+    validate: "logrotate -d %s"
+
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration

--- a/src/roles/database/tasks/configure.yml
+++ b/src/roles/database/tasks/configure.yml
@@ -69,22 +69,21 @@
     path: /etc/logrotate.d/mariadb
     create: yes
     block: |
-/var/log/mariadb/mariadb.log {
-        create 640 mysql mysql
-        notifempty
-       daily
-        rotate 3
-        missingok
-        compress
-    postrotate
-       # just if mysqld is really running
-       if test -x /usr/bin/mysqladmin && \
-          /usr/bin/mysqladmin ping &>/dev/null
-       then
-          /usr/bin/mysqladmin flush-logs
-       fi
-    endscript
-}
+        /var/log/mariadb/mariadb.log {
+            create 640 mysql mysql
+            notifempty
+            daily
+            rotate 3
+            missingok
+            compress
+            postrotate
+                if test -x /usr/bin/mysqladmin && \
+                    /usr/bin/mysqladmin ping &>/dev/null
+                then
+                   /usr/bin/mysqladmin flush-logs
+                fi
+            endscript
+        }
     validate: "logrotate -d %s"
 
 - name: Ensure MySQL is started and enabled on boot.

--- a/src/roles/database/templates/root-my.cnf.j2
+++ b/src/roles/database/templates/root-my.cnf.j2
@@ -1,3 +1,8 @@
 [client]
 user={{ mysql_root_username }}
 password={{ mysql_root_password }}
+
+# setup mysqladmin for logrotate
+[mysqladmin]
+user={{ mysql_root_username }}
+password={{ mysql_root_password }}


### PR DESCRIPTION
### Testing

I ran a deploy using this branch, and verified the contents of /etc/logrotate.d/mariadb and /root/.my.cnf afterwards.  I also tested logrotate with `logrotate -d /etc/logrotate.d/mariadb && echo $?`


### Changes

* Expand template for /root/.my.cnf
* Add blockinfile rule for src/roles/database/tasks/configure.yml

### Issues

* Closes #868 

You can delete Pull Request 871