### PR TITLE
Provide missing Extension Load option for SemanticCompoundQueries

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -46,11 +46,14 @@ list:
 
       // Disabled due to some issue on FOD wikis. Confirm, reenable if possible
       // $srfgFormats[] = 'exhibit';
-
+  
+  # Allows for the display of more than one SMW inline query in one results display set.
   - name: SemanticCompoundQueries
     composer: "mediawiki/semantic-compound-queries"
     version: "~2.1"
-
+    config: |
+      wfLoadExtension( 'SemanticCompoundQueries' );
+      
   - name: Scribunto
     repo: https://github.com/wikimedia/mediawiki-extensions-Scribunto.git
     version: "{{ mediawiki_default_branch }}"


### PR DESCRIPTION
provides missing wfLoadExtension('SemanticCompoundQueries'); config option

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
