### PR TITLE
Update haproxy.cfg.j2 to meet modern cipher and bind security requirements for enterprise systems 

### DIFF
--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -17,8 +17,8 @@ global
 	# Default ciphers to use on SSL-enabled listening sockets.
 	# For more information, see ciphers(1SSL). This list is from:
 	#  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
-	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
-	ssl-default-bind-options no-sslv3
+	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:!ECDH+3DES:!DH+3DES:RSA+AESGCM:RSA+AES:!RSA+3DES:!aNULL:!MD5:!DSS
+	ssl-default-bind-options no-sslv3 no-tls10 no-tls11
 
 
 	# Apache httpd.conf settings regarding SSL which we should verify if they


### PR DESCRIPTION
enterprise security teams are demanding that 3DES ciphers be disabled as well as TLS 1.0 and TLS 1.1 bind options. This patch does just that.

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
