### PR TITLE
Change Apache log format to Combined

### DIFF
--- a/src/roles/apache-php/tasks/main.yml
+++ b/src/roles/apache-php/tasks/main.yml
@@ -102,8 +102,20 @@
     enabled: yes
   when: docker_skip_tasks is not defined or not docker_skip_tasks
 
+# Make sure that there's a symlink for the access and error logs
+# @TODO Test this on CentOS/RHEL and possibly source /etc/httpd/envvars
+- name: Add symbolic link to Apache's access log file for easy access
+  file:
+    src: "${APACHE_LOG_DIR}/access_log"
+    dest: "${APACHE_LOG_DIR}/access.log"
+    state: link
 
-
+- name: Add symbolic link to Apache's error log file for easy access
+  file:
+    src: "${APACHE_LOG_DIR}/error_log"
+    dest: "${APACHE_LOG_DIR}/error.log"
+    state: link
+  
 # Might need these for SELinux to be turned back on
 # - name: Configure SELinux to start mysql on any port
 #   seboolean: name=mysql_connect_any state=true persistent=yes

--- a/src/roles/apache-php/templates/httpd.conf.j2
+++ b/src/roles/apache-php/templates/httpd.conf.j2
@@ -202,7 +202,7 @@ ServerName https://{{ wiki_app_fqdn }}
 {% if ansible_os_family == "RedHat" %}
 ErrorLog "logs/error_log"
 {% else %}
-ErrorLog ${APACHE_LOG_DIR}/error.log
+ErrorLog ${APACHE_LOG_DIR}/error_log
 {% endif %}
 
 #
@@ -247,19 +247,19 @@ AddOutputFilterByType DEFLATE application/x-javascript
 	#   %I -  Bytes received, including request and headers, cannot be zero.
 	#   %O -  Bytes sent, including headers, cannot be zero.
 
-	# Logging for normal requests from clients
-	LogFormat "%{X-Forwarded-For}i %h %l %u %t %D \"%r\" %>s \"%{Referer}i\" \"%{User-Agent}i\" %I %O" proxy
+	# Logging for normal requests from clients ("combined" format, prefixed with XFF header)
+	LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" proxy
 
 	# This is for non-proxied requests, meaning requests made from within the
 	# server itself or by other non-HAProxy nodes (if that's possible)
-	LogFormat             "noproxy %h %l %u %t %D \"%r\" %>s \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combined
+	LogFormat "noproxy %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" internal
 
 	SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 	{% if ansible_os_family == "RedHat" %}
-	CustomLog "logs/access_log" combined env=!forwarded
+	CustomLog "logs/access_log" internal env=!forwarded
 	CustomLog "logs/access_log" proxy env=forwarded
 	{% else %}
-	CustomLog "${APACHE_LOG_DIR}/access_log" combined env=!forwarded
+	CustomLog "${APACHE_LOG_DIR}/access_log" internal env=!forwarded
 	CustomLog "${APACHE_LOG_DIR}/access_log" proxy env=forwarded
 	{% endif %}
 

--- a/src/roles/goaccess/templates/my.goaccess.conf.j2
+++ b/src/roles/goaccess/templates/my.goaccess.conf.j2
@@ -56,7 +56,9 @@ date-format %d/%b/%Y
 # Meza Custom Log format
 log-format ~h{, } %^ %e [%d:%t %z] %D "%r" %s "%R" "%u" %^ %b
 
-#
+# XFF + NCSA Combined Log Format
+log-format ~h %h %^[%d:%t %^] "%r" %s %b "%R" "%u"
+
 # The log-format variable followed by a space or \t for
 # tab-delimited, specifies the log format string.
 #


### PR DESCRIPTION
Including XFF header first. Make GoAccess compatible with new format

### Changes

* Changed Apache Main task to include symlinks to log files in the 'Windows' style 'access.log' and 'error.log'
* Changed Apache-PHP template for httpd.conf to log to the UNIX standard location of 'access_log'
* Changed the LogFormat directive in Apache to use the NCSA Combined format with a prefixed XFF header
* Changed the GoAccess log analyzer to be compatible with the new Apache log format.

### Issues

This sets us up to use Fail2Ban to restrict "BadBots". Hopefully this will make GoAccess more useful. 

### Post-merge actions

Create a Fail2Ban role to automatically deploy fail2ban with both SSH and Apache BadBots jails.